### PR TITLE
Remove unnecessary `println!` call

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -96,7 +96,6 @@ fn expand(input: DataEnum) -> Vec<ImplItem> {
         let i = match attrs.into_iter().next() {
             None => Input {
                 name: {
-                    println!("Using default: {}", v.ident.to_string().to_snake_case());
                     v.ident.to_string().to_snake_case()
                     //
                 },


### PR DESCRIPTION
Remove `println!` call that causes messy compiler output