### PR TITLE
Disable the `Inflector/heavyweight` feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,4 +18,4 @@ pmutil = "0.5.2"
 proc-macro2 = "1"
 quote = "1"
 syn = { version = "1", features = ["fold", "full", "derive", "extra-traits"] }
-Inflector = "0.11.4"
+Inflector = { version = "0.11.4", default-features = "false" }


### PR DESCRIPTION
`is-macro` only uses `to_snake_case()` from inflector, which does not depend on the `heavyweight` feature, which brings in dependencies on `regex` and `lazy_static`.