### PR TITLE
Discard trailing punctuation before quoting fields

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -237,7 +237,7 @@ fn expand(input: DataEnum) -> Vec<ImplItem> {
                         })
                     };
 
-                    let fields: Punctuated<Ident, Token![,]> = fields
+                    let mut fields: Punctuated<Ident, Token![,]> = fields
                         .unnamed
                         .clone()
                         .into_pairs()
@@ -253,6 +253,17 @@ fn expand(input: DataEnum) -> Vec<ImplItem> {
                             }
                         })
                         .collect();
+
+                    // Make sure that we don't have any trailing punctuation
+                    // This ensure that if we have a single unnamed field,
+                    // we will produce a value of the form `(v)`,
+                    // not a single-element tuple `(v,)`
+                    if let Some(mut pair) = fields.pop() {
+                        if let Pair::Punctuated(v, _) = pair {
+                            pair = Pair::End(v);
+                        }
+                        fields.extend(std::iter::once(pair));
+                    }
 
                     items.extend(
                         Quote::new_call_site()

--- a/tests/trailing_punct.rs
+++ b/tests/trailing_punct.rs
@@ -1,0 +1,6 @@
+use is_macro::Is;
+
+#[derive(Debug, Is)]
+pub enum Enum {
+    B(usize,),
+}


### PR DESCRIPTION
If the user writes a single-field enum variant with a trailing comma,
then keeping the trailing comma will cause us to quote a single-element
tuple.