### PR TITLE
Add as_mut_variant

### DIFF
--- a/tests/arg_count.rs
+++ b/tests/arg_count.rs
@@ -5,4 +5,5 @@ pub enum Enum {
     A(),
     B(usize, usize),
     C(String),
+    D(&'static str, &'static mut u32),
 }

--- a/tests/as_mut.rs
+++ b/tests/as_mut.rs
@@ -1,0 +1,18 @@
+use is_macro::Is;
+
+#[derive(Debug, PartialEq, Is)]
+pub enum Enum {
+    A(u32),
+    B(Vec<u32>),
+}
+
+#[test]
+fn test() {
+    let mut e = Enum::A(0);
+    *e.as_mut_a().unwrap() += 1;
+    assert_eq!(e, Enum::A(1));
+
+    let mut e = Enum::B(vec![]);
+    e.as_mut_b().unwrap().push(1);
+    assert_eq!(e, Enum::B(vec![1]));
+}

--- a/tests/reference.rs
+++ b/tests/reference.rs
@@ -4,4 +4,5 @@ use is_macro::Is;
 pub enum Enum {
     A,
     B(&'static str),
+    C(&'static mut u32),
 }


### PR DESCRIPTION
Closes #9 

Previously the macro would add references by finding the first `Type::Path(..)` and then adding a reference to that. However, this is problematic.
```rust
enum Enum {
    A(&'static u32),
    B((u32, u32)),
    C([u32; 10])
}
```

Here `Enum::A` gets expanded as `&'static &u32`, `Enum::B` gets expanded as `(&u32, &u32)`, `Enum::C` gets expanded as `[&u32; 10]`. Instead, what we want is `&&'static u32`, `&(u32, u32)`, and `&[u32; 10]`, respectively.

In this PR, we add references to each type in the list of fields instead.