### PR TITLE
Generate const function

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -172,7 +172,7 @@ fn expand(input: DataEnum) -> Vec<ImplItem> {
                             impl Type {
                                 #[doc = docs_of_is]
                                 #[inline]
-                                pub fn name_of_is(&self) -> bool {
+                                pub const fn name_of_is(&self) -> bool {
                                     match *self {
                                         Self::Variant { .. } => true,
                                         _ => false,


### PR DESCRIPTION
This function can be generated as const function.

As I've seen the history, this crate is very stable. The users who want to stick on old version of Rust may be able to use the current version.