### PR TITLE
Upgrade http links to https in Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "is-macro"
 description = "Easily create methods for to use yout custom enum like Option / Result"
 version = "0.2.2"
-documentation = "http://docs.rs/is-macro"
+documentation = "https://docs.rs/is-macro"
 repository = "https://github.com/kdy1/is-macro"
 authors = ["강동윤 <kdy1997.dev@gmail.com>"]
 edition = "2018"


### PR DESCRIPTION
This is an automatically-generated PR to update plain HTTP links in Cargo.toml

If there are any issues with this, you can reach out to @/Benjins on Github who is the original author of this automated PR

In file `Cargo.toml`:
 - `http://docs.rs/is-macro` was updated. The HTTP version redirects to HTTPS, but does not enforce HSTS

