### PR TITLE
add LICENSE file

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,23 @@
+Permission is hereby granted, free of charge, to any
+person obtaining a copy of this software and associated
+documentation files (the "Software"), to deal in the
+Software without restriction, including without
+limitation the rights to use, copy, modify, merge,
+publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software
+is furnished to do so, subject to the following
+conditions:
+
+The above copyright notice and this permission notice
+shall be included in all copies or substantial portions
+of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF
+ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED
+TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT
+SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR
+IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+DEALINGS IN THE SOFTWARE.


### PR DESCRIPTION
I'm looking at packaging this crate for Fedora Linux as a dependency of [ruff](https://github.com/astral-sh/ruff), and noticed this project doesn't include the license text for the license that's specified in crate metadata.

The MIT license is one of the licenses that requires a copy of the license text to be included in (re)distributed copies of projects' source code, so missing this file presents a potential problem.

The file added with this PR is a copy of the MIT license text from the rust-lang/rust repository (it is a 100% match for what SPDX defines as the "MIT" license).

If this PR is acceptable, it would be great to get a new version released to crates.io with the license file included. Thank you!