### PR TITLE
refactor: Drop `pmutil`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,6 @@ license = "MIT"
 proc-macro = true
 
 [dependencies]
-pmutil = "0.6.0"
 proc-macro2 = "1"
 quote = "1"
 syn = { version = "2", features = ["fold", "full", "derive", "extra-traits", "fold"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "is-macro"
 description = "Derive methods for using custom enums like Option / Result"
-version = "0.3.2"
+version = "0.3.3"
 documentation = "https://docs.rs/is-macro"
 repository = "https://github.com/kdy1/is-macro"
 authors = ["강동윤 <kdy1997.dev@gmail.com>"]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -414,8 +414,8 @@ impl ItemImplExt for ItemImpl {
 
                 }
             };
-            parse(item.dump().into())
-                .unwrap_or_else(|err| panic!("with_generics failed: {}\n{}", err, item.dump()))
+            parse2(item.into_token_stream())
+                .unwrap_or_else(|err| panic!("with_generics failed: {}", err))
         };
 
         // Handle generics added by proc-macro.


### PR DESCRIPTION
This is to improve compile time